### PR TITLE
Error message formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ $ rebar3 spellcheck
 ===> Fetching rebar3_sheldon
 ===> Compiling rebar3_sheldon
 ===> Youre welcome. And if he has twins, we can do all kinds of neat experiments on them.:
-test/test_SUITE.erl:1: string: The word "Speling" is unknown. Maybe you wanted to use "speeling" or "speiling" or ....?
-test/test_SUITE.erl:2: string: The word "Commt" is unknown. Maybe you wanted to use "commit" or "commot" or "comdt" ...?
-test/test_SUITE.erl:2: string: The word "fdfdf" is unknown.
-test/test_SUITE.erl:3: comment: The word "Unicode" is unknown. Maybe you wanted to use "uncoded"?
+test/test_SUITE.erl:1: The word "Speling" in string is unknown. Maybe you wanted to use "speeling" or "speiling" or ....?
+test/test_SUITE.erl:2: The word "Commt" in string is unknown. Maybe you wanted to use "commit" or "commot" or "comdt" ...?
+test/test_SUITE.erl:2: The word "fdfdf" in string is unknown.
+test/test_SUITE.erl:3: The word "Unicode" in comment is unknown. Maybe you wanted to use "uncoded"?
 ```
 
 ## Config

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # rebar3_sheldon
+[![Hex.pm Version][hexpm version]][hexpm]
+[![Hex.pm Downloads][hexpm downloads]][hexpm]
+[![Build Status][gh badge]][gh]
+[![Erlang Versions][erlang version badge]][gh]
+
 
 A rebar plugin for spellchecking.
 
@@ -13,7 +18,7 @@ $ rebar3 compile
 Add the plugin to your rebar config:
 
 ```erlang
-{project_plugins, [{rebar3_sheldon, "~> 0.1.0"}]}.
+{project_plugins, [{rebar3_sheldon, "~> 0.1.2"}]}.
 ```
 
 Then just call your plugin directly in an existing application:
@@ -38,3 +43,11 @@ Example:
     {options, #{dummy => option}}
 ]}.
 ```
+
+<!-- Badges -->
+[hexpm]: https://hex.pm/packages/rebar3_sheldon
+[hexpm version]: https://img.shields.io/hexpm/v/rebar3_sheldon.svg?style=flat-square
+[hexpm downloads]: https://img.shields.io/hexpm/dt/rebar3_sheldon.svg?style=flat-square
+[gh]: https://github.com/vkatsuba/rebar3_sheldon/actions/workflows/ci.yml
+[gh badge]: https://img.shields.io/github/workflow/status/vkatsuba/rebar3_sheldon/CI?style=flat-square
+[erlang version badge]: https://img.shields.io/badge/erlang-23.0%20to%2024.1-blue.svg?style=flat-square

--- a/README.md
+++ b/README.md
@@ -21,44 +21,11 @@ Then just call your plugin directly in an existing application:
 $ rebar3 spellcheck
 ===> Fetching rebar3_sheldon
 ===> Compiling rebar3_sheldon
-$ ./rebar3 spellcheck
-===> spellcheck detect warning emits:[#{filename => "src/application.erl",
-                                    line => 2,
-                                    reason =>
-                                        #{bazinga => <<"Too bad Leonard">>,
-                                          misspelled_words =>
-                                              [#{candidates =>
-                                                     ["commit","commot",
-                                                      "comdt","comet","compt",
-                                                      "comte","comdt","comet",
-                                                      "compt","comte","comm",
-                                                      "comm.","comma","comme",
-                                                      "commo","commy","scomm"],
-                                                 line_number => 1,
-                                                 word => "Commt"}]},
-                                    string => "Commt",type => string},
-                                  #{filename => "test/shot_SUITE.erl",
-                                    line => 1,
-                                    reason =>
-                                        #{bazinga =>
-                                              <<"I'm exceedingly smart. I graduated college at fourteen. While my brother was getting an STD, I was getting a Ph.D. Penicillin can't take this away.">>,
-                                          misspelled_words =>
-                                              [#{candidates =>
-                                                     ["speeling","speiling",
-                                                      "spelding","spelling",
-                                                      "sperling","spieling",
-                                                      "apeling","pealing",
-                                                      "peeling","pelting",
-                                                      "perling","petling",
-                                                      "sealing","seeling",
-                                                      "selfing","seling",
-                                                      "selling","setling",
-                                                      "sapling","sipling",
-                                                      "spiling","spaeing",
-                                                      "spewing"],
-                                                 line_number => 1,
-                                                 word => "Speling"}]},
-                                    string => "Speling",type => string}]
+===> Youre welcome. And if he has twins, we can do all kinds of neat experiments on them.:
+test/test_SUITE.erl:1: string: The word "Speling" is unknown. Maybe you wanted to use "speeling" or "speiling" or ....?
+test/test_SUITE.erl:2: string: The word "Commt" is unknown. Maybe you wanted to use "commit" or "commot" or "comdt" ...?
+test/test_SUITE.erl:2: string: The word "fdfdf" is unknown.
+test/test_SUITE.erl:3: comment: The word "Unicode" is unknown. Maybe you wanted to use "uncoded"?
 ```
 
 ## Config

--- a/src/rebar3_sheldon_ast.erl
+++ b/src/rebar3_sheldon_ast.erl
@@ -29,7 +29,7 @@ spellcheck([Filename | T], Acc, RegEx) ->
                            ok ->
                                Res;
                            Warnings ->
-                               [#{filename => Filename,
+                               [#{file => Filename,
                                   line => Line,
                                   type => Type,
                                   string => Str,

--- a/src/rebar3_sheldon_prv.erl
+++ b/src/rebar3_sheldon_prv.erl
@@ -151,7 +151,7 @@ format_sheldon([#{candidates := [], word := Word} | T],
                Acc) ->
     NewAcc =
         [Acc,
-         format_text("~ts:~tp: The word ~ts in ~p is unknown.", [File, Line, Word, Type]),
+         format_text("~ts:~tp: The word ~p in ~p is unknown.", [File, Line, Word, Type]),
          $\n],
     format_sheldon(T, Data, NewAcc);
 format_sheldon([#{candidates := Candidates, word := Word} | T],
@@ -163,7 +163,7 @@ format_sheldon([#{candidates := Candidates, word := Word} | T],
     FormatCandidates = format_sheldon_candidates(Candidates, []),
     NewAcc =
         [Acc,
-         format_text("~ts:~tp: The word ~ts in ~p is unknown. Maybe you wanted to use ~ts?",
+         format_text("~ts:~tp: The word ~p in ~p is unknown. Maybe you wanted to use ~ts?",
                      [File, Line, Word, Type, FormatCandidates]),
          $\n],
     format_sheldon(T, Data, NewAcc).

--- a/src/rebar3_sheldon_prv.erl
+++ b/src/rebar3_sheldon_prv.erl
@@ -151,7 +151,7 @@ format_sheldon([#{candidates := [], word := Word} | T],
                Acc) ->
     NewAcc =
         [Acc,
-         format_text("~ts:~tp: ~ts: The word ~p is unknown.", [File, Line, Type, Word]),
+         format_text("~ts:~tp: The word ~p in ~ts is unknown.", [File, Line, Type, Word]),
          $\n],
     format_sheldon(T, Data, NewAcc);
 format_sheldon([#{candidates := Candidates, word := Word} | T],
@@ -163,7 +163,7 @@ format_sheldon([#{candidates := Candidates, word := Word} | T],
     FormatCandidates = format_sheldon_candidates(Candidates, []),
     NewAcc =
         [Acc,
-         format_text("~ts:~tp: ~ts: The word ~p is unknown. Maybe you wanted to use ~ts?",
+         format_text("~ts:~tp: The word ~p in ~ts is unknown. Maybe you wanted to use ~ts?",
                      [File, Line, Type, Word, FormatCandidates]),
          $\n],
     format_sheldon(T, Data, NewAcc).

--- a/src/rebar3_sheldon_prv.erl
+++ b/src/rebar3_sheldon_prv.erl
@@ -59,7 +59,8 @@ do(State) ->
         [] ->
             {ok, State};
         Warnings -> %% @TODO: sheldon will return warning for TODO word
-            {error, format_results({"spellcheck detect warning emits", Warnings})}
+            [#{reason := #{bazinga := SheldonMsg}} | _] = Warnings,
+            {error, format_results({unicode:characters_to_list(SheldonMsg), Warnings})}
     end.
 
 -spec format_error(any()) -> iolist().
@@ -130,14 +131,14 @@ format_results({SheldonMsg, Results}) ->
                 SheldonMsg ++ ":\n",
                 Results).
 
--spec format_result(maps:map()) -> binary().
+-spec format_result(maps:map()) -> string().
 format_result(#{file := File,
                 line := Line,
                 string := Msg,
                 type := Type}) ->
     format_text("~ts:~tp: ~ts: ~ts", [File, Line, Type, Msg]).
 
--spec format_text(string(), list()) -> binary().
+-spec format_text(string(), list()) -> string().
 format_text(Text, Args) ->
     Formatted = io_lib:format(Text, Args),
-    unicode:characters_to_binary(Formatted).
+    unicode:characters_to_list(Formatted).

--- a/src/rebar3_sheldon_prv.erl
+++ b/src/rebar3_sheldon_prv.erl
@@ -151,7 +151,7 @@ format_sheldon([#{candidates := [], word := Word} | T],
                Acc) ->
     NewAcc =
         [Acc,
-         format_text("~ts:~tp: The word ~p in ~ts is unknown.", [File, Line, Type, Word]),
+         format_text("~ts:~tp: The word ~ts in ~p is unknown.", [File, Line, Word, Type]),
          $\n],
     format_sheldon(T, Data, NewAcc);
 format_sheldon([#{candidates := Candidates, word := Word} | T],
@@ -163,8 +163,8 @@ format_sheldon([#{candidates := Candidates, word := Word} | T],
     FormatCandidates = format_sheldon_candidates(Candidates, []),
     NewAcc =
         [Acc,
-         format_text("~ts:~tp: The word ~p in ~ts is unknown. Maybe you wanted to use ~ts?",
-                     [File, Line, Type, Word, FormatCandidates]),
+         format_text("~ts:~tp: The word ~ts in ~p is unknown. Maybe you wanted to use ~ts?",
+                     [File, Line, Word, Type, FormatCandidates]),
          $\n],
     format_sheldon(T, Data, NewAcc).
 

--- a/src/rebar3_sheldon_prv.erl
+++ b/src/rebar3_sheldon_prv.erl
@@ -127,7 +127,7 @@ get_ignore_regex(SpellcheckConfig) ->
 
 -spec format_results({string(), [maps:map()]}) -> string().
 format_results({SheldonMsg, Results}) ->
-    lists:foldr(fun(Result, Acc) -> [Acc, format_result(Result), $\n] end,
+    lists:foldr(fun(Result, Acc) -> [Acc, format_result(Result)] end,
                 SheldonMsg ++ ":\n",
                 Results).
 
@@ -160,9 +160,18 @@ format_sheldon([#{candidates := Candidates, word := Word} | T],
                  type := Type} =
                    Data,
                Acc) ->
+    FormatCandidates = format_sheldon_candidates(Candidates, []),
     NewAcc =
         [Acc,
-         format_text("~ts:~tp: ~ts: The word ~p is unknown. Maybe you wanted to use ~p",
-                     [File, Line, Type, Word, Candidates]),
+         format_text("~ts:~tp: ~ts: The word ~p is unknown. Maybe you wanted to use ~ts?",
+                     [File, Line, Type, Word, FormatCandidates]),
          $\n],
     format_sheldon(T, Data, NewAcc).
+
+-spec format_sheldon_candidates([any()], [[[any()] | char()]]) -> [[[any()] | char()]].
+format_sheldon_candidates([], Acc) ->
+    Acc;
+format_sheldon_candidates([Candidate], Acc) ->
+    [Acc, format_text("~p", [Candidate])];
+format_sheldon_candidates([Candidate | T], Acc) ->
+    format_sheldon_candidates(T, [Acc, format_text("~p or ", [Candidate])]).

--- a/src/rebar3_sheldon_prv.erl
+++ b/src/rebar3_sheldon_prv.erl
@@ -59,7 +59,7 @@ do(State) ->
         [] ->
             {ok, State};
         Warnings -> %% @TODO: sheldon will return warning for TODO word
-            {error, io_lib:format("spellcheck detect warning emits: ~p", [Warnings])}
+            {error, format_results({"spellcheck detect warning emits", Warnings})}
     end.
 
 -spec format_error(any()) -> iolist().
@@ -119,3 +119,25 @@ get_ignored_files(SpellcheckConfig) ->
 -spec get_ignore_regex(list()) -> [string()].
 get_ignore_regex(SpellcheckConfig) ->
     proplists:get_value(ignore_regex, SpellcheckConfig, undefined).
+
+%% =============================================================================
+%% Error formatter
+%% =============================================================================
+
+-spec format_results({string(), [maps:map()]}) -> string().
+format_results({SheldonMsg, Results}) ->
+    lists:foldr(fun(Result, Acc) -> [Acc, format_result(Result), $\n] end,
+                SheldonMsg ++ ":\n",
+                Results).
+
+-spec format_result(maps:map()) -> binary().
+format_result(#{file := File,
+                line := Line,
+                string := Msg,
+                type := Type}) ->
+    format_text("~ts:~tp: ~ts: ~ts", [File, Line, Type, Msg]).
+
+-spec format_text(string(), list()) -> binary().
+format_text(Text, Args) ->
+    Formatted = io_lib:format(Text, Args),
+    unicode:characters_to_binary(Formatted).

--- a/test/rebar3_sheldon_SUITE.erl
+++ b/test/rebar3_sheldon_SUITE.erl
@@ -116,5 +116,5 @@ init_test_app() ->
     rebar_state:set(State1, spellcheck, [Files, IgnoredFiles, IgnoreRegEx]).
 
 -spec get_error_msg(tuple()) -> any().
-get_error_msg({error, [_, Error, _]}) ->
+get_error_msg({error, [_, [_, Error, _]]}) ->
     Error.

--- a/test/rebar3_sheldon_SUITE.erl
+++ b/test/rebar3_sheldon_SUITE.erl
@@ -54,9 +54,10 @@ emits_warnings(_Config) ->
     Files = {files, ["src/test_warning.erl"]},
     State2 = rebar_state:set(State1, spellcheck, [Files]),
     %% Our parsers don't crash on unparseable or non-existent files
-    {error, ErrorMsg} = spellcheck(State2),
+    Error = spellcheck(State2),
+    ErrorMsg = get_error_msg(Error),
     %% Check warning message
-    ?assertEqual(ErrorMsg, string:find(ErrorMsg, "spellcheck detect warning emits:")).
+    ?assertEqual(ErrorMsg, string:find(ErrorMsg, "src/test_warning.erl:3:")).
 
 -spec ignore_regex(ct_suite:ct_config()) -> ok | no_return().
 ignore_regex(_Config) ->
@@ -74,9 +75,10 @@ unicode(_Config) ->
     {ok, State1} = init(),
     Files = {files, ["src/test_unicode.erl"]},
     State2 = rebar_state:set(State1, spellcheck, [Files]),
-    {error, ErrorMsg} = spellcheck(State2),
+    Error = spellcheck(State2),
+    ErrorMsg = get_error_msg(Error),
     %% Check warning message
-    ?assertEqual(ErrorMsg, string:find(ErrorMsg, "spellcheck detect warning emits:")).
+    ?assertEqual(ErrorMsg, string:find(ErrorMsg, "src/test_unicode.erl:8:")).
 
 %% =============================================================================
 %% Helpers
@@ -112,3 +114,7 @@ init_test_app() ->
           "src/*_unicode.erl"]},
     IgnoreRegEx = {ignore_regex, "[_@./#&+-=*]"},
     rebar_state:set(State1, spellcheck, [Files, IgnoredFiles, IgnoreRegEx]).
+
+-spec get_error_msg(tuple()) -> any().
+get_error_msg({error, [_, Error, _]}) ->
+    Error.

--- a/test/test_app/src/test_warning.erl
+++ b/test/test_app/src/test_warning.erl
@@ -1,3 +1,3 @@
 -module(test_warning).
 
-% Word commt is wrong
+% Word commt is fffrong


### PR DESCRIPTION
Update format error to:
```erlang
===> You're welcome. And if he has twins, we can do all kinds of neat experiments on them.:
test/test_SUITE.erl:1: The word "Speling" in string is unknown. Maybe you wanted to use "speeling" or "speiling" or ....?
test/test_SUITE.erl:2: The word "Commt" in string is unknown. Maybe you wanted to use "commit" or "commot" or "comdt" ...?
test/test_SUITE.erl:2: The word "fdfdf" in string is unknown.
test/test_SUITE.erl:3: The word "Unicode" in comment is unknown. Maybe you wanted to use "uncoded"?
```